### PR TITLE
Added an option to specify the 'holder' div directly rather than by its ID

### DIFF
--- a/demo/directdivdemo.html
+++ b/demo/directdivdemo.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<title>Direct DIV Demo</title>
+<script type="text/javascript" src="http://code.jquery.com/jquery-latest.min.js"></script>
+<script type="text/javascript" src="../src/jquery.youtubeplaylist.js"></script>
+
+<script type="text/ecmascript">
+
+		$(function() {
+		  var holder = $('div.youtube');
+			$("ul.demo1").ytplaylist({holder: holder});
+		});
+
+</script>
+
+<style type="text/css">
+
+  .youtube {
+    background: #f3f3f3;
+    padding: 10px;
+    float: left;
+    border: 1px solid #e3e3e3;
+    margin-bottom:15px;
+  }
+  
+  ul {
+      float: left;
+      margin: 0;
+      padding: 0;
+      width: 220px;
+  }
+  
+  ul li {
+    list-style-type: none;
+    display:block;
+    background: #f1f1f1;
+    float: left;
+    width: 216px;
+    margin-bottom: 5px;
+    padding:2px;
+  }
+  
+  ul li img {
+    width: 120px;
+    float: left;
+    margin-right: 5px;
+    border: 1px solid #999;
+  }
+  
+  ul li a {
+    font-family: georgia;
+    text-decoration: none;
+    display: block;
+    color: #000;
+  }
+  
+  .currentvideo {
+    background: #e6e6e6;
+  }
+
+</style>
+
+</head>
+
+<body>
+  <h1>jQuery YouTube playlist plugin</h1>
+  <p><a href="#">back to blog post</a></p>
+  <p>The html code for the following example</p>
+  <code>
+    <pre>
+    &lt;div class=&quot;youtube&quot;&gt;&lt;/div&gt;
+    &lt;ul class=&quot;demo1&quot;&gt;
+        &lt;li&gt;&lt;a href=&quot;http://www.youtube.com/watch?v=QBBWKvY-VDc&quot;&gt;Video 1&lt;/a&gt;&lt;/li&gt;
+        &lt;li&gt;&lt;a href=&quot;http://www.youtube.com/watch?v=ZXMQqLnRhRI&quot;&gt;Video 2&lt;/a&gt;&lt;/li&gt;
+        &lt;li&gt;&lt;a href=&quot;http://www.youtube.com/watch?v=Wvo-g_JvURI&quot;&gt;Video 3&lt;/a&gt;&lt;/li&gt;
+    &lt;/ul&gt;
+    </pre>
+  </code>
+  <p>javascript for the following example</p>
+  <code>
+    <pre>
+    var holder = $('div.youtube');
+    $("ul.demo1").ytplaylist({holder: holder});
+    </pre>
+  </code>
+
+  <div class="youtube"></div>
+    <ul class="demo1">
+        <li><a href="http://www.youtube.com/watch?v=QBBWKvY-VDc">Video 1</a></li>
+        <li><a href="http://www.youtube.com/watch?v=ZXMQqLnRhRI">Video 2</a></li>
+        <li><a href="http://youtu.be/L0CsLefLisE">Video 3</a></li>
+    </ul>
+</div>
+
+</body>
+</html>

--- a/src/jquery.youtubeplaylist.js
+++ b/src/jquery.youtubeplaylist.js
@@ -239,7 +239,8 @@
           link.parent('li').addClass('currentvideo').html(self.getNewEmbedCode(self.options, link.data('yt-id')));
         }
         else {
-          $('#' + options.holderId).html(self.getNewEmbedCode(self.options, link.data('yt-id')));
+          var holder = (options.holder ? options.holder : $('#' + options.holderId));
+          holder.html(self.getNewEmbedCode(self.options, link.data('yt-id')));
           link.parent().parent('ul').find('li.currentvideo').removeClass('currentvideo');
           link.parent('li').addClass('currentvideo');
         }
@@ -289,7 +290,8 @@
           $link.parent('li').addClass('currentvideo').html($thisImage);
         }
         else {
-          $('#' + options.holderId).html($thisImage);
+          var holder = (options.holder ? options.holder : $('#' + options.holderId));
+          holder.html($thisImage);
           $link.closest('ul').find('li.currentvideo').removeClass('currentvideo');
           $link.parent('li').addClass('currentvideo');
         }


### PR DESCRIPTION
The use case I have does not allow me to specify an ID for the container DIV for the video, so I have modified your plugin slightly to allow a user to specify an option 'holder' that is a direct reference to the DIV that is to hold the video.

This is demonstrated in the file demo/directdivdemo.html

I hope others find this minor modification useful too.

Cheers

Dave
