### PR TITLE
youtube embed rel option fix

### DIFF
--- a/src/jquery.youtubeplaylist.js
+++ b/src/jquery.youtubeplaylist.js
@@ -62,7 +62,7 @@
       this._protocol = (this.options.secure === 'auto') ? window.location.protocol === 'https:' ? 'https://' : 'http://' :
         this.options.secure ? 'https://' : 'http://';
       this._autoPlay = (this.options.autoPlay) ? '&autoplay=1' : '';
-      this._showRelated = (this.options.showRelated) ? '&rel=1' : '';
+      this._showRelated = '&rel=' + ((this.options.showRelated) ? '1' : '0');
       this._fullscreen = (this.options.allowFullScreen) ? '&fs=1' : '';
       this.init();
   }


### PR DESCRIPTION
youtube embed option rel defaults to true, so when showRelated is set to false, you have to set it to rel to 0 also, otherwise it would default to 1 and would show it anyway.
